### PR TITLE
feat : 행정구역 코드 API 스케줄링과 데이터 파싱하여 넣기

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,23 +38,16 @@ dependencies {
 
     //mysql
     implementation 'mysql:mysql-connector-java:8.0.31'
-
     //redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
-
     // H2
     runtimeOnly 'com.h2database:h2'
-
     //JUnit4
     testImplementation("org.junit.vintage:junit-vintage-engine") {
         exclude group: "org.hamcrest", module: "hamcrest-core"
     }
-
-
     // security
     implementation 'org.springframework.boot:spring-boot-starter-security'
-    testImplementation 'org.springframework.boot:spring-security-test'
-
     // jwt
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'

--- a/src/main/java/com/strawberryfarm/fitingle/FitingleApplication.java
+++ b/src/main/java/com/strawberryfarm/fitingle/FitingleApplication.java
@@ -1,15 +1,36 @@
 package com.strawberryfarm.fitingle;
 
+import com.strawberryfarm.fitingle.domain.adminarea.service.AdminAreaService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.annotation.Scheduled;
 
+@EnableScheduling
 @EnableJpaAuditing
 @SpringBootApplication
-public class FitingleApplication {
+@RequiredArgsConstructor
+public class FitingleApplication implements CommandLineRunner {
+
+	private final AdminAreaService adminAreaService;
 
 	public static void main(String[] args) {
 		SpringApplication.run(FitingleApplication.class, args);
 	}
 
+	// 처음 어플리케이션 시작시 (행정구역 코드 API -> DB)실행
+	@Override
+	public void run(String... args) throws Exception {
+		adminAreaService.insertRegionCodes();
+	}
+
+	// 매주 일요일 자정에 (행정구역 코드 API -> DB)실행
+	@Scheduled(cron = "0 0 0 * * SUN")
+	public void scheduledRegionDeleteAndInsert() {
+		adminAreaService.updateRegionCodes();
+	}
 }

--- a/src/main/java/com/strawberryfarm/fitingle/config/RestTemplateConfig.java
+++ b/src/main/java/com/strawberryfarm/fitingle/config/RestTemplateConfig.java
@@ -1,0 +1,14 @@
+package com.strawberryfarm.fitingle.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateConfig {
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+}
+

--- a/src/main/java/com/strawberryfarm/fitingle/domain/adminarea/controller/AdminAreaController.java
+++ b/src/main/java/com/strawberryfarm/fitingle/domain/adminarea/controller/AdminAreaController.java
@@ -1,8 +1,24 @@
 package com.strawberryfarm.fitingle.domain.adminarea.controller;
 
+
+import com.strawberryfarm.fitingle.domain.adminarea.service.AdminAreaService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+
 @RestController
+@RequestMapping(value = "/contents", produces = MediaType.APPLICATION_JSON_VALUE)
+@RequiredArgsConstructor
 public class AdminAreaController {
 
+    private final AdminAreaService adminAreaService;
+
+    @GetMapping("/adminarea")
+    public ResponseEntity<?> getContentsList() {
+        return ResponseEntity.ok(adminAreaService.getAllAdminAreas());
+    }
 }

--- a/src/main/java/com/strawberryfarm/fitingle/domain/adminarea/dto/AdminAreaResponseDTO.java
+++ b/src/main/java/com/strawberryfarm/fitingle/domain/adminarea/dto/AdminAreaResponseDTO.java
@@ -15,8 +15,17 @@ import java.util.List;
 @AllArgsConstructor
 @NoArgsConstructor
 public class AdminAreaResponseDTO implements BaseDto {
-    private String sidoName;
-    private List<Sigungu> sigungu;
+
+    private List<Sido> sido;
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class Sido {
+        private String sidoName;
+        private List<Sigungu> sigungu;
+    }
 
     @Getter
     @Builder

--- a/src/main/java/com/strawberryfarm/fitingle/domain/adminarea/dto/AdminAreaResponseDTO.java
+++ b/src/main/java/com/strawberryfarm/fitingle/domain/adminarea/dto/AdminAreaResponseDTO.java
@@ -1,0 +1,39 @@
+package com.strawberryfarm.fitingle.domain.adminarea.dto;
+
+import com.strawberryfarm.fitingle.dto.BaseDto;
+import com.strawberryfarm.fitingle.dto.ResultDto;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class AdminAreaResponseDTO implements BaseDto {
+    private String sidoName;
+    private List<Sigungu> sigungu;
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class Sigungu {
+        private String sigunguName;
+        private String bCode;
+    }
+
+    @Override
+    public ResultDto doResultDto(String message, String errorCode) {
+        return ResultDto.builder()
+                .message(message)
+                .data(this)
+                .errorCode(errorCode)
+                .build();
+    }
+
+}

--- a/src/main/java/com/strawberryfarm/fitingle/domain/adminarea/dto/RegionCodesResponseDTO.java
+++ b/src/main/java/com/strawberryfarm/fitingle/domain/adminarea/dto/RegionCodesResponseDTO.java
@@ -1,0 +1,23 @@
+package com.strawberryfarm.fitingle.domain.adminarea.dto;
+
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class RegionCodesResponseDTO {
+    private List<RegionCode> regcodes;
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class RegionCode {
+        private String code;
+        private String name;
+    }
+}

--- a/src/main/java/com/strawberryfarm/fitingle/domain/adminarea/dto/TestDto.java
+++ b/src/main/java/com/strawberryfarm/fitingle/domain/adminarea/dto/TestDto.java
@@ -1,5 +1,0 @@
-package com.strawberryfarm.fitingle.domain.adminarea.dto;
-
-public class TestDto {
-
-}

--- a/src/main/java/com/strawberryfarm/fitingle/domain/adminarea/repository/AdminAreaRepository.java
+++ b/src/main/java/com/strawberryfarm/fitingle/domain/adminarea/repository/AdminAreaRepository.java
@@ -4,5 +4,5 @@ import com.strawberryfarm.fitingle.domain.adminarea.entity.AdminArea;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface AdminAreaRepository extends JpaRepository<AdminArea, Long> {
-
+    AdminArea save(AdminArea adminArea);
 }

--- a/src/main/java/com/strawberryfarm/fitingle/domain/adminarea/repository/AdminAreaRepository.java
+++ b/src/main/java/com/strawberryfarm/fitingle/domain/adminarea/repository/AdminAreaRepository.java
@@ -3,6 +3,9 @@ package com.strawberryfarm.fitingle.domain.adminarea.repository;
 import com.strawberryfarm.fitingle.domain.adminarea.entity.AdminArea;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface AdminAreaRepository extends JpaRepository<AdminArea, Long> {
     AdminArea save(AdminArea adminArea);
+    List<AdminArea> findAllByOrderBySidoCodeAscNameAsc();
 }

--- a/src/main/java/com/strawberryfarm/fitingle/domain/adminarea/service/AdminAreaService.java
+++ b/src/main/java/com/strawberryfarm/fitingle/domain/adminarea/service/AdminAreaService.java
@@ -26,7 +26,7 @@ public class AdminAreaService {
     private final RestTemplate restTemplate;
     private final AdminAreaRepository areaRepository;
 
-    public final String BASE_URL = "https://grpc-proxy-server-mkvo6j4wsq-du.a.run.app/v1/regcodes?regcode_pattern=";
+    private static final String BASE_URL = "https://grpc-proxy-server-mkvo6j4wsq-du.a.run.app/v1/regcodes?regcode_pattern=";
 
 
     // '시도' 이름을 간략화하기 위한 상수 매핑

--- a/src/main/java/com/strawberryfarm/fitingle/domain/adminarea/service/AdminAreaService.java
+++ b/src/main/java/com/strawberryfarm/fitingle/domain/adminarea/service/AdminAreaService.java
@@ -1,5 +1,111 @@
 package com.strawberryfarm.fitingle.domain.adminarea.service;
 
-public class AdminAreaService {
 
+import com.strawberryfarm.fitingle.domain.adminarea.dto.RegionCodesResponseDTO;
+import com.strawberryfarm.fitingle.domain.adminarea.dto.RegionCodesResponseDTO.RegionCode;
+import com.strawberryfarm.fitingle.domain.adminarea.entity.AdminArea;
+import com.strawberryfarm.fitingle.domain.adminarea.repository.AdminAreaRepository;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestTemplate;
+
+
+@Service
+@Log4j2
+@RequiredArgsConstructor
+public class AdminAreaService {
+    private final RestTemplate restTemplate;
+    private final AdminAreaRepository areaRepository;
+
+    public String BASE_URL = "https://grpc-proxy-server-mkvo6j4wsq-du.a.run.app/v1/regcodes?regcode_pattern=";
+
+    @Transactional
+    public void updateRegionCodes() {
+        deleteAllRegionCodes();
+        insertRegionCodes();
+    }
+
+    private void deleteAllRegionCodes() {
+        areaRepository.deleteAll();
+    }
+
+    public void insertRegionCodes() {
+        Map<String, AdminArea> areasToSaveMap = new HashMap<>();
+        List<RegionCode> sidoCodes = regionCodes("*00000000");
+
+        for (RegionCode sido : sidoCodes) {
+            String sidoCode = sido.getCode().substring(0, 2);
+            String sidoName = formatSidoName(sido.getName());
+            AdminArea sidoArea = AdminArea.builder()
+                    .sidoCode(sidoCode)
+                    .gunguCode(sidoCode + "000")
+                    .name(sidoName + " 전체")
+                    .build();
+
+            areasToSaveMap.put(sidoName + " 전체", sidoArea);
+            List<RegionCode> gunguDongCodes = regionCodes(sidoCode + "*");
+            for (RegionCode gunguDong : gunguDongCodes) {
+                if (gunguDong.getCode().endsWith("00000000") || !gunguDong.getCode().endsWith("0000")) {
+                    continue;
+                }
+                String gunguDongCode = gunguDong.getCode().substring(0, 5);
+                String gunguDongName = formatGunguName(gunguDong.getName(), sidoName);
+                AdminArea area = AdminArea.builder()
+                        .sidoCode(sidoCode)
+                        .gunguCode(gunguDongCode)
+                        .name(gunguDongName)
+                        .build();
+                areasToSaveMap.put(sidoCode + "-" + gunguDongName, area);
+            }
+        }
+        List<AdminArea> areasToSaveList = new ArrayList<>(areasToSaveMap.values());
+        areaRepository.saveAll(areasToSaveList);
+    }
+
+    private String formatGunguName(String name, String sidoName) {
+        String[] splitNames = name.split(" ");
+        if (splitNames.length > 1) {
+            return sidoName + " " + splitNames[1];
+        }
+        return name;
+    }
+
+    private String formatSidoName(String name) {
+        if (name.endsWith("00000000")) {
+            return name.substring(0, name.length() - 8) + " 전체";
+        }
+        name = name.replace("특별시", "시");
+        name = name.replace("광역시", "시");
+        name = name.replace("충청남도", "충남");
+        name = name.replace("충청북도", "충북");
+        name = name.replace("경상남도", "경남");
+        name = name.replace("경상북도", "경북");
+        name = name.replace("전라남도", "전남");
+        name = name.replace("전라북도", "전북");
+        name = name.replace("경기도", "경기");
+        name = name.replace("제주특별자치도", "제주");
+        name = name.replace("강원특별자치도", "강원");
+        return name.trim();
+    }
+
+    private List<RegionCode> regionCodes(String pattern) {
+        ResponseEntity<RegionCodesResponseDTO> response = restTemplate.getForEntity(BASE_URL + pattern, RegionCodesResponseDTO.class);
+
+        // API 호출에 문제가 없다면 응답 본문(body)의 데이터를 반환
+        if (response.getStatusCode() == HttpStatus.OK && response.getBody() != null) {
+            return response.getBody().getRegcodes();
+        }
+        // API 호출에 문제가 있거나 응답 본문이 없는 경우 로그 출력, 빈 리스트를 반환
+        log.error("행정코드 불러오기 에러. HTTP 상태 코드: {0000}", response.getStatusCode());
+        return new ArrayList<>();
+    }
 }
+

--- a/src/main/java/com/strawberryfarm/fitingle/domain/adminarea/service/AdminAreaService.java
+++ b/src/main/java/com/strawberryfarm/fitingle/domain/adminarea/service/AdminAreaService.java
@@ -1,14 +1,15 @@
 package com.strawberryfarm.fitingle.domain.adminarea.service;
 
 
+import com.strawberryfarm.fitingle.domain.adminarea.dto.AdminAreaResponseDTO;
 import com.strawberryfarm.fitingle.domain.adminarea.dto.RegionCodesResponseDTO;
 import com.strawberryfarm.fitingle.domain.adminarea.dto.RegionCodesResponseDTO.RegionCode;
 import com.strawberryfarm.fitingle.domain.adminarea.entity.AdminArea;
 import com.strawberryfarm.fitingle.domain.adminarea.repository.AdminAreaRepository;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+
+import com.strawberryfarm.fitingle.dto.ResultDto;
+import java.util.*;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.http.HttpStatus;
@@ -25,7 +26,274 @@ public class AdminAreaService {
     private final RestTemplate restTemplate;
     private final AdminAreaRepository areaRepository;
 
-    public String BASE_URL = "https://grpc-proxy-server-mkvo6j4wsq-du.a.run.app/v1/regcodes?regcode_pattern=";
+    public final String BASE_URL = "https://grpc-proxy-server-mkvo6j4wsq-du.a.run.app/v1/regcodes?regcode_pattern=";
+
+
+    // '시도' 이름을 간략화하기 위한 상수 매핑
+    private static final Map<String, String> SIDO_NAME_MAP = Map.ofEntries(
+            Map.entry("특별시", ""),
+            Map.entry("광역시", ""),
+            Map.entry("충청남도", "충남"),
+            Map.entry("충청북도", "충북"),
+            Map.entry("경상남도", "경남"),
+            Map.entry("경상북도", "경북"),
+            Map.entry("전라남도", "전남"),
+            Map.entry("전라북도", "전북"),
+            Map.entry("경기도", "경기"),
+            Map.entry("제주특별자치도", "제주"),
+            Map.entry("강원특별자치도", "강원")
+    );
+
+    ///-------------관리 지역 API 데이터 넣기 메소드-----------------
+    /**
+     * 행정구역 코드를 DB에 저장한다.
+     * '시도'와 '구/군/동' 단위로 분리하여 저장하며, 세종특별자치시는 수동으로 추가한다.
+     * 예시: 서울특별시 -> 서울 전체, 서울특별시 종로구 -> 종로구
+     */
+
+    @Transactional
+    public void insertRegionCodes() {
+        Map<String, AdminArea> areasToSaveMap = new HashMap<>();
+
+        for (RegionCode sido : getSidoCodes()) {
+            AdminArea sidoArea = buildSidoArea(sido);
+            String sidoKey = sidoArea.getSidoCode();
+            areasToSaveMap.put(sidoKey, sidoArea);
+
+
+            for (RegionCode gunguDong : getGunguDongCodes(sido)) {
+                AdminArea gunguArea = buildGunguArea(gunguDong, sido);
+                String gunguKey = gunguArea.getSidoCode() + gunguArea.getGunguCode();
+                areasToSaveMap.put(gunguKey, gunguArea);
+
+            }
+        }
+        addSejongAreasToMap(areasToSaveMap);
+        areaRepository.saveAll(new ArrayList<>(areasToSaveMap.values()));
+    }
+
+    //세종시 임의로 추가
+    private void addSejongAreasToMap(Map<String, AdminArea> areasToSaveMap) {
+        String sejongCode = "32";
+
+        // "세종 전체" 항목 추가
+        AdminArea sejongGeneralArea = AdminArea.builder()
+                .sidoCode(sejongCode)
+                .gunguCode(sejongCode + "000")
+                .name("세종 전체")
+                .build();
+        areasToSaveMap.put(sejongCode + "000", sejongGeneralArea);
+
+        // "세종특별자치시" 항목 추가
+        AdminArea sejongCityArea = AdminArea.builder()
+                .sidoCode(sejongCode)
+                .gunguCode(sejongCode + "001") // 이 코드는 적절한 구/동 코드로 수정이 필요할 수 있다.
+                .name("세종특별자치시")
+                .build();
+        areasToSaveMap.put(sejongCode + "001", sejongCityArea);
+    }
+
+    /**
+     * '시도' 행정구역 객체를 구축한다.
+     * 예시: 서울특별시 -> 서울 전체
+     */
+    private AdminArea buildSidoArea(RegionCode sido) {
+        String sidoCode = extractSidoCode(sido);
+        String sidoName = formatSidoName(sido.getName());
+        return AdminArea.builder()
+                .sidoCode(sidoCode)
+                .gunguCode(sidoCode + "000")
+                .name(sidoName)
+                .build();
+    }
+
+    /**
+     * '구/군/동' 행정구역 객체를 구축한다.
+     * 예시: 서울특별시 종로구 -> 종로구
+     */
+    private AdminArea buildGunguArea(RegionCode gunguDong, RegionCode sido) {
+        String gunguCode = extractGunguCode(gunguDong);
+        String gunguName = formatGunguName(gunguDong.getName());
+        return AdminArea.builder()
+                .sidoCode(extractSidoCode(sido))
+                .gunguCode(gunguCode)
+                .name(gunguName)
+                .build();
+    }
+
+    /**
+     * '시도' 코드를 조회한다.
+     * 예시: 서울특별시, 부산광역시, 대구광역시 등
+     */
+    private List<RegionCode> getSidoCodes() {
+        return regionCodes("*00000000");
+    }
+
+    /**
+     * 특정 '시도'에 해당하는 '구/군/동' 행정구역 코드들을 조회한다.
+     * 예시: 서울특별시(11)에 해당하는 구/군/동 행정구역 코드 조회 -> 종로구(11010), 중구(11020), ... 등
+     */
+    private List<RegionCode> getGunguDongCodes(RegionCode sido) {
+        List<RegionCode> originalCodes = regionCodes(extractSidoCode(sido) + "*00000");
+        List<RegionCode> filteredCodes = new ArrayList<>();
+
+        //시도 코드 제외
+        for (RegionCode code : originalCodes) {
+            if (!code.getCode().equals(sido.getCode())) {
+                filteredCodes.add(code);
+            }
+        }
+        return filteredCodes;
+    }
+
+
+    /**
+     * '시도' 코드에서 '구/군/동' 코드를 추출한다.
+     * 예시: code가 "1100000000"인 경우 -> "11" 반환
+     */
+    private String extractSidoCode(RegionCode code) {
+        return code.getCode().substring(0, 2);
+    }
+
+
+    /**
+     * 전체 행정구역 코드에서 '구/군/동' 코드를 추출한다.
+     * 예시: code가 "1101056000"인 경우 -> "11010" 반환
+     */
+    private String extractGunguCode(RegionCode code) {
+        return code.getCode().substring(0, 5);
+    }
+
+    /**
+     * '구/군/동' 이름을 형식화한다. 이름이 두 단어 이상일 경우, 첫 단어를 제외한 나머지를 반환한다.
+     * 예시: name이 "서울특별시 종로구"인 경우 -> "종로구" 반환
+     */
+    private String formatGunguName(String name) {
+        String[] splitNames = name.split(" ");
+        if (splitNames.length > 1) {
+            return Arrays.stream(splitNames, 1, splitNames.length)
+                    .collect(Collectors.joining(" "));
+        }
+        return name;
+    }
+
+    /**
+     * '시도' 이름을 형식화한다. 이름을 간략화하고, "전체"를 붙여서 반환한다.
+     * 예시: 서울특별시 -> 서울 전체
+     * 예시: name이 "서울특별시"인 경우 -> "서울 전체" 반환
+     */
+    private String formatSidoName(String name) {
+        for (Map.Entry<String, String> entry : SIDO_NAME_MAP.entrySet()) {
+            if (name.contains(entry.getKey())) {
+                String newName = (name.replace(entry.getKey(), entry.getValue()) + " 전체").trim();
+                return newName;
+            }
+        }
+        return name.trim();
+    }
+
+
+    /**
+     * 주어진 패턴에 맞는 행정구역 코드들을 조회한다.
+     * 예시: pattern이 "*00000000"인 경우 -> '시도' 행정구역 코드 리스트 반환
+     */
+    private List<RegionCode> regionCodes(String pattern) {
+        ResponseEntity<RegionCodesResponseDTO> response = restTemplate.getForEntity(BASE_URL + pattern,
+                RegionCodesResponseDTO.class);
+
+        // API 호출에 문제가 없다면 응답 본문(body)의 데이터를 반환
+        if (response.getStatusCode() == HttpStatus.OK && response.getBody() != null) {
+            return response.getBody().getRegcodes();
+        }
+        // API 호출에 문제가 있거나 응답 본문이 없는 경우 로그 출력, 빈 리스트를 반환 -> 예외 던지기 필요.
+        log.error("행정코드 불러오기 에러. HTTP 상태 코드: {0000}", response.getStatusCode());
+        return new ArrayList<>();
+    }
+
+
+    ///-------------저장된 관리 지역 데이터 가져오기 메소드-----------------
+    /**
+     * 모든 행정구역 정보를 가져와 '시도' 별로 그룹화하여 반환한다. 예: {31: [울산 전체, 중구, 남구, 동구, 북구, 울주군]}
+     */
+    public ResultDto<List<AdminAreaResponseDTO>> getAllAdminAreas() {
+        try {
+            List<AdminArea> adminAreas = areaRepository.findAllByOrderBySidoCodeAscNameAsc();
+            Map<String, List<AdminArea>> groupedBySido = groupBySido(adminAreas);
+
+            List<AdminAreaResponseDTO> result = new ArrayList<>();
+            for (Map.Entry<String, List<AdminArea>> entry : groupedBySido.entrySet()) {
+                result.add(convertToAdminAreaDTO(entry));
+            }
+            if (result.isEmpty()) {
+                return ResultDto.<List<AdminAreaResponseDTO>>builder()
+                        .message("관리 지역 정보를 찾을 수 없습니다.")
+                        .data(null)
+                        .errorCode("2000")
+                        .build();
+            }
+
+            return ResultDto.<List<AdminAreaResponseDTO>>builder()
+                    .message("관리 지역 정보를 성공적으로 가져왔습니다.")
+                    .data(result)
+                    .errorCode(null)
+                    .build();
+
+        } catch(Exception e) {
+            return ResultDto.<List<AdminAreaResponseDTO>>builder()
+                    .message("관리 지역 정보를 가져오는 중 오류가 발생하였습니다.")
+                    .data(null)
+                    .errorCode("2001")
+                    .build();
+        }
+    }
+
+    /**
+     * 행정구역 리스트를 '시도' 코드별로 그룹화한다.
+     * 예: [울산 중구, 울산 남구, 울산 동구, ...] -> {31: [중구, 남구, 동구, ...]}
+     */
+    private Map<String, List<AdminArea>> groupBySido(List<AdminArea> adminAreas) {
+        Map<String, List<AdminArea>> map = new LinkedHashMap<>();
+        for (AdminArea area : adminAreas) {
+            String key = area.getSidoCode();
+            if (!map.containsKey(key)) {
+                map.put(key, new ArrayList<>());
+            }
+            map.get(key).add(area);
+        }
+        return map;
+    }
+
+    /**
+     * '시도'별로 그룹화된 행정구역 정보를 DTO로 변환한다.
+     * 예: {31: [중구, 남구, 동구, ...]} -> AdminAreaResponseDTO(울산, [울산 전체, 중구, 남구, 동구, ...])
+     * sigungus 항목이 1개만 있고, 전체 항목도 존재하면 전체 항목 제거 ->  세종의 경우 '세종 전체'는 삭제한다.
+     */
+    private AdminAreaResponseDTO convertToAdminAreaDTO(Map.Entry<String, List<AdminArea>> entry) {
+        List<AdminArea> areas = entry.getValue();
+
+        String sidoName = "";
+        List<AdminAreaResponseDTO.Sigungu> sigungus = new ArrayList<>();
+        AdminAreaResponseDTO.Sigungu entireArea = null;
+
+        for (AdminArea area : areas) {
+            if (area.getName().endsWith(" 전체")) {
+                sidoName = area.getName().replace(" 전체", "");
+                entireArea = new AdminAreaResponseDTO.Sigungu(sidoName + "전체", area.getGunguCode());
+            } else {
+                String sigunguName = area.getName().replace(sidoName + " ", " ");
+                sigungus.add(new AdminAreaResponseDTO.Sigungu(sigunguName, area.getGunguCode()));
+            }
+        }
+
+        // 만약 sigungus 항목이 1개만 있고, 전체 항목도 존재하면 전체 항목 제거
+        if (sigungus.size() == 1 && entireArea != null) {
+            entireArea = null;
+        } else if (entireArea != null) {
+            sigungus.add(0, entireArea);
+        }
+        return new AdminAreaResponseDTO(sidoName, sigungus);
+
+    }
 
     @Transactional
     public void updateRegionCodes() {
@@ -35,77 +303,6 @@ public class AdminAreaService {
 
     private void deleteAllRegionCodes() {
         areaRepository.deleteAll();
-    }
-
-    public void insertRegionCodes() {
-        Map<String, AdminArea> areasToSaveMap = new HashMap<>();
-        List<RegionCode> sidoCodes = regionCodes("*00000000");
-
-        for (RegionCode sido : sidoCodes) {
-            String sidoCode = sido.getCode().substring(0, 2);
-            String sidoName = formatSidoName(sido.getName());
-            AdminArea sidoArea = AdminArea.builder()
-                    .sidoCode(sidoCode)
-                    .gunguCode(sidoCode + "000")
-                    .name(sidoName + " 전체")
-                    .build();
-
-            areasToSaveMap.put(sidoName + " 전체", sidoArea);
-            List<RegionCode> gunguDongCodes = regionCodes(sidoCode + "*");
-            for (RegionCode gunguDong : gunguDongCodes) {
-                if (gunguDong.getCode().endsWith("00000000") || !gunguDong.getCode().endsWith("0000")) {
-                    continue;
-                }
-                String gunguDongCode = gunguDong.getCode().substring(0, 5);
-                String gunguDongName = formatGunguName(gunguDong.getName(), sidoName);
-                AdminArea area = AdminArea.builder()
-                        .sidoCode(sidoCode)
-                        .gunguCode(gunguDongCode)
-                        .name(gunguDongName)
-                        .build();
-                areasToSaveMap.put(sidoCode + "-" + gunguDongName, area);
-            }
-        }
-        List<AdminArea> areasToSaveList = new ArrayList<>(areasToSaveMap.values());
-        areaRepository.saveAll(areasToSaveList);
-    }
-
-    private String formatGunguName(String name, String sidoName) {
-        String[] splitNames = name.split(" ");
-        if (splitNames.length > 1) {
-            return sidoName + " " + splitNames[1];
-        }
-        return name;
-    }
-
-    private String formatSidoName(String name) {
-        if (name.endsWith("00000000")) {
-            return name.substring(0, name.length() - 8) + " 전체";
-        }
-        name = name.replace("특별시", "시");
-        name = name.replace("광역시", "시");
-        name = name.replace("충청남도", "충남");
-        name = name.replace("충청북도", "충북");
-        name = name.replace("경상남도", "경남");
-        name = name.replace("경상북도", "경북");
-        name = name.replace("전라남도", "전남");
-        name = name.replace("전라북도", "전북");
-        name = name.replace("경기도", "경기");
-        name = name.replace("제주특별자치도", "제주");
-        name = name.replace("강원특별자치도", "강원");
-        return name.trim();
-    }
-
-    private List<RegionCode> regionCodes(String pattern) {
-        ResponseEntity<RegionCodesResponseDTO> response = restTemplate.getForEntity(BASE_URL + pattern, RegionCodesResponseDTO.class);
-
-        // API 호출에 문제가 없다면 응답 본문(body)의 데이터를 반환
-        if (response.getStatusCode() == HttpStatus.OK && response.getBody() != null) {
-            return response.getBody().getRegcodes();
-        }
-        // API 호출에 문제가 있거나 응답 본문이 없는 경우 로그 출력, 빈 리스트를 반환
-        log.error("행정코드 불러오기 에러. HTTP 상태 코드: {0000}", response.getStatusCode());
-        return new ArrayList<>();
     }
 }
 

--- a/src/test/java/com/strawberryfarm/fitingle/domain/adminarea/service/AdminAreaServiceTest.java
+++ b/src/test/java/com/strawberryfarm/fitingle/domain/adminarea/service/AdminAreaServiceTest.java
@@ -1,0 +1,36 @@
+package com.strawberryfarm.fitingle.domain.adminarea.service;
+import com.strawberryfarm.fitingle.domain.adminarea.repository.AdminAreaRepository;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import org.springframework.web.client.RestTemplate;
+
+
+public class AdminAreaServiceTest {
+
+    @InjectMocks
+    private AdminAreaService adminAreaService;
+
+    @Mock
+    private RestTemplate restTemplate;
+
+    @Mock
+    private AdminAreaRepository adminAreaRepository;
+
+
+    @Test
+    public void testInsertRegionCodes() {
+
+    }
+
+    @Test
+    public void getAllAdminAreas() {
+    }
+
+    @Test
+    public void updateRegionCodes() {
+    }
+}


### PR DESCRIPTION
1. 행정구역 코드 API 통해 데이터 가져오고 파싱하여 DB에 넣기.
   1-1.RestTemplateConfig : 빈 등록 (API를 호출할 때 사용되는 빈)
   1-2.RegionCodesResponseDTO : API 불러온 데이터 담을 객체(시/도 , 시/군/구 )
   1-3.AdminAreaService :  
      1-3-1. API 호출하여 데이터 받기
      1-3-2. 코드 뒤 8자리가 모두 0인 경우 제일뒤에 “전체”를 붙임(xxx시 xxx의 형식)
      1-3-3. “서울특별시 종로구”와 같이 풀어져 써진 행정구역 “서울시 종로구”로 변경 후 담기
   1-4.AdminAreaRepository: 테이블에 데이터 저장하기

2.스케줄러 설정 및 프로젝트 실행 시 마다 위의 서비스 실행.
   2-1. FitingApplication : CommandLineRunner 상속 -> run 메소드를 통해 어플리케이션 시작 시점마다 실행하기 위해 
   2-2. FitingApplication : @EnableScheduling ,@Scheduled(cron = "0 0 0 * * SUN")-> 매주 일요일 자정 마다 API 데이터 db에
    업데이트(삭제,삽입) 진행되는 기능.