### PR TITLE
feat : 어플리케이션 실행시 field 관련 s3 이미지 불러와서 DB 넣기, 전체 필드 불러오기

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,6 +64,14 @@ dependencies {
     //smtp 의존성 추가
     implementation 'org.springframework.boot:spring-boot-starter-mail'
 
+    //aws s3
+    implementation 'software.amazon.awssdk:s3:2.17.43'
+
+    // Mockito의 인라인 모킹 -> Final 클래스 및 메서드 모킹 위해
+    testImplementation 'org.mockito:mockito-inline:3.12.4'
+
+
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/strawberryfarm/fitingle/FitingleApplication.java
+++ b/src/main/java/com/strawberryfarm/fitingle/FitingleApplication.java
@@ -13,24 +13,9 @@ import org.springframework.scheduling.annotation.Scheduled;
 @EnableScheduling
 @EnableJpaAuditing
 @SpringBootApplication
-@RequiredArgsConstructor
-public class FitingleApplication implements CommandLineRunner {
-
-	private final AdminAreaService adminAreaService;
+public class FitingleApplication {
 
 	public static void main(String[] args) {
 		SpringApplication.run(FitingleApplication.class, args);
-	}
-
-	// 처음 어플리케이션 시작시 (행정구역 코드 API -> DB)실행
-	@Override
-	public void run(String... args) throws Exception {
-		adminAreaService.insertRegionCodes();
-	}
-
-	// 매주 일요일 자정에 (행정구역 코드 API -> DB)실행
-	@Scheduled(cron = "0 0 0 * * SUN")
-	public void scheduledRegionDeleteAndInsert() {
-		adminAreaService.updateRegionCodes();
 	}
 }

--- a/src/main/java/com/strawberryfarm/fitingle/config/S3Config.java
+++ b/src/main/java/com/strawberryfarm/fitingle/config/S3Config.java
@@ -1,0 +1,31 @@
+package com.strawberryfarm.fitingle.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+
+
+@Configuration
+public class S3Config {
+
+    @Value("${cloud.aws.credentials.accessKey}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secretKey}")
+    private String secretKey;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public S3Client s3Client() {
+        return S3Client.builder()
+                .region(Region.of(region))
+                .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create(accessKey, secretKey)))
+                .build();
+    }
+}

--- a/src/main/java/com/strawberryfarm/fitingle/domain/adminarea/controller/AdminAreaController.java
+++ b/src/main/java/com/strawberryfarm/fitingle/domain/adminarea/controller/AdminAreaController.java
@@ -17,7 +17,7 @@ public class AdminAreaController {
 
     private final AdminAreaService adminAreaService;
 
-    @GetMapping("/adminarea")
+    @GetMapping("/adminArea")
     public ResponseEntity<?> getContentsList() {
         return ResponseEntity.ok(adminAreaService.getAllAdminAreas());
     }

--- a/src/main/java/com/strawberryfarm/fitingle/domain/field/controller/FieldController.java
+++ b/src/main/java/com/strawberryfarm/fitingle/domain/field/controller/FieldController.java
@@ -1,8 +1,27 @@
 package com.strawberryfarm.fitingle.domain.field.controller;
 
+import com.strawberryfarm.fitingle.domain.field.service.FieldService;
+import com.strawberryfarm.fitingle.dto.ResultDto;
+import java.net.URL;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-@RestController
-public class FieldController {
 
+@RestController
+@RequestMapping(value = "/field", produces = MediaType.APPLICATION_JSON_VALUE)
+@RequiredArgsConstructor
+public class FieldController {
+    private final FieldService fieldService;
+
+    @GetMapping
+    public ResponseEntity<ResultDto> getAllFields() {
+        return ResponseEntity.ok(fieldService.getAllFields());
+    }
 }

--- a/src/main/java/com/strawberryfarm/fitingle/domain/field/dto/FieldsReponseDTO.java
+++ b/src/main/java/com/strawberryfarm/fitingle/domain/field/dto/FieldsReponseDTO.java
@@ -1,0 +1,30 @@
+package com.strawberryfarm.fitingle.domain.field.dto;
+
+import com.strawberryfarm.fitingle.dto.BaseDto;
+import com.strawberryfarm.fitingle.dto.ResultDto;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class FieldsReponseDTO implements BaseDto {
+
+    private Long fieldId;
+    private String fieldName;
+    private String image;
+
+    @Override
+    public ResultDto doResultDto(String message, String errorCode) {
+        return ResultDto.builder()
+                .message(message)
+                .data(this)
+                .errorCode(errorCode)
+                .build();
+
+    }
+}

--- a/src/main/java/com/strawberryfarm/fitingle/domain/field/dto/TestDto.java
+++ b/src/main/java/com/strawberryfarm/fitingle/domain/field/dto/TestDto.java
@@ -1,5 +1,0 @@
-package com.strawberryfarm.fitingle.domain.field.dto;
-
-public class TestDto {
-
-}

--- a/src/main/java/com/strawberryfarm/fitingle/domain/field/entity/Field.java
+++ b/src/main/java/com/strawberryfarm/fitingle/domain/field/entity/Field.java
@@ -15,12 +15,18 @@ import javax.persistence.Id;
 import javax.persistence.OneToMany;
 import javax.persistence.OneToOne;
 import javax.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 
 @Entity
 @Getter
 @Table(name = "field")
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
 public class Field extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/strawberryfarm/fitingle/domain/field/service/FieldService.java
+++ b/src/main/java/com/strawberryfarm/fitingle/domain/field/service/FieldService.java
@@ -1,5 +1,103 @@
 package com.strawberryfarm.fitingle.domain.field.service;
 
+import com.strawberryfarm.fitingle.domain.field.dto.FieldsReponseDTO;
+import com.strawberryfarm.fitingle.domain.field.entity.Field;
+import com.strawberryfarm.fitingle.domain.field.repository.FieldRepository;
+import com.strawberryfarm.fitingle.dto.ResultDto;
+import java.net.URL;
+import java.util.ArrayList;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Response;
+import software.amazon.awssdk.services.s3.model.S3Object;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
 public class FieldService {
 
+    private final S3Client s3Client;
+    private final FieldRepository fieldRepository;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucketName;
+
+    @Value("${cloud.aws.s3.url}")
+    private String s3BaseUrl;
+
+    private List<S3Object> getFieldObjectsFromS3() {
+        //AWS SDK for Java V2에서 제공하는 클래스로, Amazon S3의 listObjectsV2
+        ListObjectsV2Request listObjectsV2Request = ListObjectsV2Request.builder()
+                .bucket(bucketName)
+                .prefix("fields/")
+                .build();
+
+        ListObjectsV2Response listObjectsV2Response = s3Client.listObjectsV2(listObjectsV2Request);
+
+        List<S3Object> filteredList = new ArrayList<>();
+        for (S3Object s3Object : listObjectsV2Response.contents()) {
+            if (!s3Object.key().equals("fields/")) {
+                filteredList.add(s3Object);
+            }
+        }
+        return filteredList;
+    }
+
+
+    private String mapToKoreanName(String fieldName) {
+        // 나머지 스포츠와 그에 대응하는 한글 이름 추가 필요.
+        Map<String, String> nameMapping = new HashMap<>();
+        nameMapping.put("baseball", "야구");
+        nameMapping.put("basketball", "농구");
+        nameMapping.put("soccer", "축구");
+        nameMapping.put("swimming", "수영");
+        nameMapping.put("golf", "골프");
+        nameMapping.put("running", "런닝");
+        nameMapping.put("tennis", "테니스");
+        return nameMapping.getOrDefault(fieldName, fieldName);
+    }
+
+    public void saveFieldsToDatabase() {
+        List<S3Object> fieldObjects = getFieldObjectsFromS3();
+
+        for (S3Object fieldObject : fieldObjects) {
+            String objectKey = fieldObject.key(); // 예: "fields/baseball-20231021.jpg"
+            String fieldName = objectKey.replace("fields/", "").split("-")[0]; // "baseball"
+
+            Field field = Field.builder()
+                    .name(mapToKoreanName(fieldName))
+                    .imageUrl(constructImageUrl(objectKey)) // 실제 S3에서의 URL 구성
+                    .build();
+
+            fieldRepository.save(field);
+        }
+    }
+    private String constructImageUrl(String objectKey) {
+        return s3BaseUrl + objectKey;
+    }
+
+    public ResultDto getAllFields() {
+        List<Field> fields = fieldRepository.findAll();
+        List<FieldsReponseDTO> fieldDtos = new ArrayList<>();
+        for (Field field : fields) {
+            FieldsReponseDTO dto = FieldsReponseDTO.builder()
+                    .fieldId(field.getId())
+                    .fieldName(field.getName())
+                    .image(field.getImageUrl())
+                    .build();
+            fieldDtos.add(dto);
+        }
+        return ResultDto.builder()
+                .message("분야 정보를 성공적으로 가져왔습니다.")
+                .errorCode("1111")
+                .data(fieldDtos)
+                .build();
+    }
 }

--- a/src/main/java/com/strawberryfarm/fitingle/scheduler/FieldScheduler.java
+++ b/src/main/java/com/strawberryfarm/fitingle/scheduler/FieldScheduler.java
@@ -1,0 +1,19 @@
+package com.strawberryfarm.fitingle.scheduler;
+
+import com.strawberryfarm.fitingle.domain.field.service.FieldService;
+import javax.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class FieldScheduler {
+
+    private final FieldService fieldService;
+
+    //처음 어플리케이션 시작시 (s3 -> DB)실행
+    @PostConstruct
+    public void initFields() {
+        fieldService.saveFieldsToDatabase();
+    }
+}

--- a/src/main/java/com/strawberryfarm/fitingle/scheduler/RegionCodeScheduler.java
+++ b/src/main/java/com/strawberryfarm/fitingle/scheduler/RegionCodeScheduler.java
@@ -1,0 +1,26 @@
+package com.strawberryfarm.fitingle.scheduler;
+
+import com.strawberryfarm.fitingle.domain.adminarea.service.AdminAreaService;
+import javax.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class RegionCodeScheduler {
+
+    private final AdminAreaService adminAreaService;
+
+    // 처음 어플리케이션 시작시 (행정구역 코드 API -> DB)실행
+    @PostConstruct
+    public void initRegionCodes() {
+        adminAreaService.insertRegionCodes();
+    }
+
+    // 매주 일요일 자정에 (행정구역 코드 API -> DB)실행
+    @Scheduled(cron = "0 0 0 * * SUN")
+    public void scheduledRegionDeleteAndInsert() {
+        adminAreaService.updateRegionCodes();
+    }
+}

--- a/src/test/java/com/strawberryfarm/fitingle/domain/field/controller/FieldControllerTest.java
+++ b/src/test/java/com/strawberryfarm/fitingle/domain/field/controller/FieldControllerTest.java
@@ -1,0 +1,57 @@
+package com.strawberryfarm.fitingle.domain.field.controller;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.strawberryfarm.fitingle.domain.field.dto.FieldsReponseDTO;
+import com.strawberryfarm.fitingle.domain.field.service.FieldService;
+import com.strawberryfarm.fitingle.dto.ResultDto;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class FieldControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private FieldService fieldService;
+
+    @BeforeEach
+    public void setup() {
+        FieldsReponseDTO fieldsReponseDTO = FieldsReponseDTO.builder()
+                .fieldId(1L)
+                .fieldName("축구")
+                .image("https://strawberry-bucket.s3.ap-northeast-2.amazonaws.com/fields/soccer-20231021.jpg")
+                .build();
+
+        ResultDto resultDto = fieldsReponseDTO.doResultDto("분야 정보를 성공적으로 가져왔습니다.", "1111");
+        when(fieldService.getAllFields()).thenReturn(resultDto);
+    }
+
+    @Test
+    @DisplayName("Fields를 정상적으로 조회하는지 검증")
+    public void testGetAllFields() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.get("/field")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.message").value("분야 정보를 성공적으로 가져왔습니다."))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.fieldId").value(1L))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.fieldName").value("축구"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.image")
+                        .value("https://strawberry-bucket.s3.ap-northeast-2.amazonaws.com/fields/soccer-20231021.jpg"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.errorCode").value("1111"));
+    }
+}

--- a/src/test/java/com/strawberryfarm/fitingle/domain/field/service/FieldServiceTest.java
+++ b/src/test/java/com/strawberryfarm/fitingle/domain/field/service/FieldServiceTest.java
@@ -1,0 +1,93 @@
+package com.strawberryfarm.fitingle.domain.field.service;
+
+import com.strawberryfarm.fitingle.domain.field.entity.Field;
+import com.strawberryfarm.fitingle.domain.field.repository.FieldRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Response;
+import software.amazon.awssdk.services.s3.model.S3Object;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+
+public class FieldServiceTest {
+
+    // AWS S3 관련 작업을 테스트하기 위해 S3Client를 Mock
+    @Mock
+    private S3Client s3Client;
+
+    // 데이터베이스 관련 작업을 테스트하기 위해 FieldRepository를 Mock
+    @Mock
+    private FieldRepository fieldRepository;
+
+    // Mock된 의존성들을 FieldService에 자동으로 주입
+    @InjectMocks
+    private FieldService fieldService;
+
+    // 각 테스트 전에 Mock들을 초기화
+    @BeforeEach
+    public void setup() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    @DisplayName("S3에서 필드 데이터를 가져와 데이터베이스에 저장하는 기능 검증")
+    void saveFieldsToDatabase() {
+        // Given
+
+        // AWS S3 응답을 시뮬레이션하기 위해 S3Object를 Mock
+        S3Object object = mock(S3Object.class);
+        when(object.key()).thenReturn("fields/baseball-20231021.jpg");
+
+        // AWS S3에서 객체를 나열하는 응답을 시뮬레이션하기 위해 응답을 Mock
+        ListObjectsV2Response response = mock(ListObjectsV2Response.class);
+        when(response.contents()).thenReturn(Arrays.asList(object));
+
+        // Mock된 S3 클라이언트의 동작을 정의
+        when(s3Client.listObjectsV2(any(ListObjectsV2Request.class))).thenReturn(response);
+
+        // When
+
+        // 테스트할 메서드를 호출
+        fieldService.saveFieldsToDatabase();
+
+        // Then
+
+        // 리포지토리의 save 메서드가 호출되었는지 확인
+        verify(fieldRepository).save(any(Field.class));
+    }
+
+    @Test
+    @DisplayName("모든 필드를 정상적으로 조회하는 기능 검증")
+    void getAllFields() {
+        // Given
+
+        // 데이터베이스의 데이터를 시뮬레이션하기 위해 Field 엔터티를 Mock
+        Field field = mock(Field.class);
+        when(field.getId()).thenReturn(1L);
+        when(field.getName()).thenReturn("야구");
+        when(field.getImageUrl()).thenReturn("some-url");
+
+        // Mock된 리포지토리의 동작을 정의
+        when(fieldRepository.findAll()).thenReturn(Collections.singletonList(field));
+
+        // When
+        // 테스트할 메서드를 호출
+        fieldService.getAllFields();
+
+        // Then
+
+        // 리포지토리의 findAll 메서드가 호출되었는지 확인
+        verify(fieldRepository).findAll();
+    }
+}


### PR DESCRIPTION
> 1. 스케줄러 컴포넌트 빼기

- FitingleApplication -> scheduler/FieldScheduler 추가 , scheduler/RegionCodeScheduler 이동.

   1.    FieldScheduler(추가) : 어플리케이션 시작 시  s3에서 이미지 URL 호출 하여 DB에 넣기 위해.(자세한 건 아래 fieldService)
   
> 2.Gradle 추가
- software.amazon.awssdk:s3:2.17.43: AWS S3 서비스와 상호작용하기 위한 AWS SDK 
- org.mockito:mockito-inline:3.12.4: Final 클래스와 메서드를 모킹하기 위한 Mockito의 인라인 모킹 기능 지원을 위해 추가

> 3.Field 이미지 호출하여 URL 넣기, /field 호출 시 전체 필드 데이터 넘겨주기 
- FieldsReponseDTO : field db 결과 담을 객체
- FieldController : /field 엔드포인트 접근 시 해당 reponse 객체에 FieldsReponseDTO 담아서 던져주기
- S3Config : AWS S3 서비스와의 연결 설정을 담당하며, 필요한 설정값은 yml 파일에서 가져와 사용하고, S3Client 객체를 생성
- FieldService : 
*몇개 이미지만 baseball-20231021.jpg 이러한 형태로 데모 이미지를 s3에 올림
   1. saveFieldsToDatabase : 
     1-1. s3의 field 폴더내에 존재하는 이미지 url(baseball-20231021.jpg) 가져온다
     1-2. 영문 단어 -> 한글로 map 통해 변경
     1-3. DB에 넣기 (스케줄러를 통해 어플리케이션 시작 시 실행)
   2. getAllFields :
     1-1. /field 호출 시 실행된다.
     1-2.  DB의 모든 field 데이터를 가져오고 해당 API 명세서에 맞도록 객체를 반환 해준다. 

> 4.테스트 코드

- FieldControllerTest , FieldServiceTest : GPT에 물어보면서 일단 코드를 구현했는데..너무 어려움 공부좀 더해서 이해 필요
