### PR TITLE
정책 변경으로 인한 리펙터링

### DIFF
--- a/src/main/java/com/strawberryfarm/fitingle/config/SecurityConfig.java
+++ b/src/main/java/com/strawberryfarm/fitingle/config/SecurityConfig.java
@@ -7,6 +7,7 @@ import com.strawberryfarm.fitingle.security.filters.JwtAuthorizationFilter;
 import java.util.Collections;
 import javax.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -22,6 +23,7 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 @EnableWebSecurity
 @Configuration
 @RequiredArgsConstructor
+@Slf4j
 public class SecurityConfig {
 	private final JwtTokenManager jwtTokenManager;
 	private final RedisTemplate redisTemplate;

--- a/src/main/java/com/strawberryfarm/fitingle/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/strawberryfarm/fitingle/domain/auth/controller/AuthController.java
@@ -70,19 +70,21 @@ public class AuthController {
 		ResultDto resultDto = authService.refreshAccessToken(userId,
 			authAccessTokenRefreshRequestDto);
 
-		if (resultDto.getData() == null) {
-			return ResponseEntity.ok(ResultDto.builder()
-				.message(resultDto.getMessage())
-				.data(null)
-				.errorCode(resultDto.getErrorCode())
-				.build());
-		}
+//		if (resultDto.getData() == null) {
+//			return ResponseEntity.ok(ResultDto.builder()
+//				.message(resultDto.getMessage())
+//				.data(null)
+//				.errorCode(resultDto.getErrorCode())
+//				.build());
+//		}
+//
+//		refreshCookie(request, response, resultDto);
 
-		refreshCookie(request, response, resultDto);
+//		return ResponseEntity.ok(RefreshTokenResponseDto.builder()
+//				.accessToken(((RefreshTokenResponseVo)resultDto.getData()).getAccessToken())
+//			.build().doResultDto(ErrorCode.SUCCESS.getMessage(), ErrorCode.SUCCESS.getCode()));
 
-		return ResponseEntity.ok(RefreshTokenResponseDto.builder()
-				.accessToken(((RefreshTokenResponseVo)resultDto.getData()).getAccessToken())
-			.build().doResultDto(ErrorCode.SUCCESS.getMessage(), ErrorCode.SUCCESS.getCode()));
+		return ResponseEntity.ok(resultDto);
 	}
 
 	private static void refreshCookie(HttpServletRequest request, HttpServletResponse response,
@@ -114,21 +116,22 @@ public class AuthController {
 	public ResponseEntity<?> login(@RequestBody AuthLoginRequestDto authLoginRequestDto, HttpServletResponse response) {
 		ResultDto resultDto = authService.login(authLoginRequestDto);
 
-		if (resultDto.getData() == null) {
-			return ResponseEntity.ok(ResultDto.builder()
-				.message(resultDto.getMessage())
-				.data(null)
-				.errorCode(resultDto.getErrorCode())
-				.build());
-		}
+//		if (resultDto.getData() == null) {
+//			return ResponseEntity.ok(ResultDto.builder()
+//				.message(resultDto.getMessage())
+//				.data(null)
+//				.errorCode(resultDto.getErrorCode())
+//				.build());
+//		}
 
-		initCookie(response, resultDto);
+//		initCookie(response, resultDto);
 
-		return ResponseEntity.ok(ResultDto.builder()
-			.message(resultDto.getMessage())
-			.data(((AuthLoginResponseVo)resultDto.getData()).getAuthLoginResponseDto())
-			.errorCode(resultDto.getErrorCode())
-			.build());
+//		return ResponseEntity.ok(ResultDto.builder()
+//			.message(resultDto.getMessage())
+//			.data(((AuthLoginResponseVo)resultDto.getData()).getAuthLoginResponseDto())
+//			.errorCode(resultDto.getErrorCode())
+//			.build());
+		return ResponseEntity.ok(resultDto);
 	}
 
 	@PostMapping("/signup")
@@ -149,7 +152,6 @@ public class AuthController {
 			.sameSite("None")
 			.httpOnly(true)
 			.secure(true)
-			.domain("localhost")
 			.maxAge(Duration.ofDays(1))
 			.build();
 		response.addHeader("Set-Cookie",cookie.toString());

--- a/src/main/java/com/strawberryfarm/fitingle/domain/auth/dto/AuthLoginResponseDto.java
+++ b/src/main/java/com/strawberryfarm/fitingle/domain/auth/dto/AuthLoginResponseDto.java
@@ -1,16 +1,18 @@
 package com.strawberryfarm.fitingle.domain.auth.dto;
 
+import com.strawberryfarm.fitingle.dto.BaseDto;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 
 @Getter
-@Builder
+@SuperBuilder
 @AllArgsConstructor
 @NoArgsConstructor
-public class AuthLoginResponseDto {
+public class AuthLoginResponseDto extends BaseDto {
     private String email;
     private String nickName;
     private String accessToken;
+    private String refreshToken;
 }

--- a/src/main/java/com/strawberryfarm/fitingle/domain/auth/dto/RefreshTokenResponseDto.java
+++ b/src/main/java/com/strawberryfarm/fitingle/domain/auth/dto/RefreshTokenResponseDto.java
@@ -13,4 +13,5 @@ import lombok.experimental.SuperBuilder;
 @SuperBuilder
 public class RefreshTokenResponseDto extends BaseDto {
 	private String accessToken;
+	private String refreshToken;
 }

--- a/src/main/java/com/strawberryfarm/fitingle/domain/auth/service/AuthService.java
+++ b/src/main/java/com/strawberryfarm/fitingle/domain/auth/service/AuthService.java
@@ -1,6 +1,7 @@
 package com.strawberryfarm.fitingle.domain.auth.service;
 
 import com.strawberryfarm.fitingle.domain.ErrorCode;
+import com.strawberryfarm.fitingle.domain.auth.dto.RefreshTokenResponseDto;
 import com.strawberryfarm.fitingle.domain.auth.dto.RefreshTokenResponseVo;
 import com.strawberryfarm.fitingle.domain.auth.dto.emailDto.EmailCertificationConfirmRequestDto;
 import com.strawberryfarm.fitingle.domain.auth.dto.emailDto.EmailCertificationConfirmResponseDto;
@@ -133,12 +134,20 @@ public class AuthService {
 
 			refreshRefreshToken(email, refreshToken);
 
-			return AuthLoginResponseVo.builder()
-				.authLoginResponseDto(AuthLoginResponseDto.builder()
-					.email(email)
-					.nickName(nickname)
-					.accessToken(accessToken)
-					.build())
+//			return AuthLoginResponseVo.builder()
+//				.authLoginResponseDto(AuthLoginResponseDto.builder()
+//					.email(email)
+//					.nickName(nickname)
+//					.accessToken(accessToken)
+//					.build())
+//				.refreshToken(refreshToken)
+//				.build()
+//				.doResultDto(ErrorCode.SUCCESS.getMessage(), ErrorCode.SUCCESS.getCode());
+
+			return AuthLoginResponseDto.builder()
+				.email(email)
+				.nickName(nickname)
+				.accessToken(accessToken)
 				.refreshToken(refreshToken)
 				.build()
 				.doResultDto(ErrorCode.SUCCESS.getMessage(), ErrorCode.SUCCESS.getCode());
@@ -185,7 +194,7 @@ public class AuthService {
 
 			refreshRefreshToken(email, refreshToken);
 
-			return RefreshTokenResponseVo.builder()
+			return RefreshTokenResponseDto.builder()
 				.accessToken(accessToken)
 				.refreshToken(refreshToken)
 				.build()

--- a/src/main/java/com/strawberryfarm/fitingle/security/JwtTokenManager.java
+++ b/src/main/java/com/strawberryfarm/fitingle/security/JwtTokenManager.java
@@ -113,7 +113,6 @@ public class JwtTokenManager {
 		if (!StringUtils.hasText(refreshToken)) {
 			return ErrorCode.EMPTY_REFRESH_TOKEN;
 		}
-
 		try {
 			Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(refreshToken).getBody();
 			return ErrorCode.SUCCESS;

--- a/src/main/java/com/strawberryfarm/fitingle/security/filters/JwtAuthorizationFilter.java
+++ b/src/main/java/com/strawberryfarm/fitingle/security/filters/JwtAuthorizationFilter.java
@@ -23,26 +23,27 @@ import org.springframework.web.filter.OncePerRequestFilter;
 @Slf4j
 @RequiredArgsConstructor
 public class JwtAuthorizationFilter extends OncePerRequestFilter {
-	public static final String TOKEN_HEADER = "Authorization";
+	public static final String ACCESS_TOKEN_HEADER = "Authorization";
+	public static final String REFRESH_TOKEN_HEADER = "Refresh-Token";
 	public static final String TOKEN_PREFIX = "Bearer :";
 	private final RedisTemplate redisTemplate;
 	private final JwtTokenManager jwtTokenManager;
 
 	@Override
 	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
-		String authorizationHeaderValue = request.getHeader(TOKEN_HEADER);
-		String refreshToken = "";
+		String authorizationHeaderValue = request.getHeader(ACCESS_TOKEN_HEADER);
+		String refreshToken = request.getHeader(REFRESH_TOKEN_HEADER);
 
 		//쿠키에서 refresh 토큰을 가져옴
-		Cookie[] cookies = request.getCookies();
-
-		if (cookies != null) {
-			for (Cookie cookie : cookies) {
-				if (cookie.getName().equals("refreshToken")) {
-					refreshToken = cookie.getValue();
-				}
-			}
-		}
+//		Cookie[] cookies = request.getCookies();
+//
+//		if (cookies != null) {
+//			for (Cookie cookie : cookies) {
+//				if (cookie.getName().equals("refreshToken")) {
+//					refreshToken = cookie.getValue();
+//				}
+//			}
+//		}
 
 		if (!ObjectUtils.isEmpty(authorizationHeaderValue)) {
 			//토큰 타입 확인


### PR DESCRIPTION
1. 토큰 정책 변경 - refresh Token이 http-only 쿠키로 할 경우 react 클라이언트에서 쿠키에 저장이 안되는 문제 
    - 일단 헤더에 담아 보내는 것으로 변경하여 해결, 기존 문제는 계속 체크 예정 
    - AuthController refresh와 access 토큰 두개의 토큰을 응답으로 보냄 
    - Dto 변경 
    - JwtAuthorizationFilter refresh 토큰을 쿠키에서 가져오던 것에서 헤더를 읽어 오는 것으로 변경