### PR TITLE
feat : 로그 aop 기능 추가.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ out/
 /src/main/resources/application.yml
 /src/main/resources/application-main.yml
 /src/main/resources/application-dev.yml
+
+### log ###
+logs/

--- a/build.gradle
+++ b/build.gradle
@@ -84,6 +84,11 @@ dependencies {
     // Springdoc
     implementation 'org.springdoc:springdoc-openapi-ui:1.6.9'
 
+    //aop
+    implementation 'org.springframework.boot:spring-boot-starter-aop' //직접 추가
+
+
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/strawberryfarm/fitingle/FitingleApplication.java
+++ b/src/main/java/com/strawberryfarm/fitingle/FitingleApplication.java
@@ -6,6 +6,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.EnableAspectJAutoProxy;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.annotation.Scheduled;

--- a/src/main/java/com/strawberryfarm/fitingle/annotation/Retry.java
+++ b/src/main/java/com/strawberryfarm/fitingle/annotation/Retry.java
@@ -1,0 +1,12 @@
+package com.strawberryfarm.fitingle.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Retry {
+    int value() default 3;
+}

--- a/src/main/java/com/strawberryfarm/fitingle/annotation/Trace.java
+++ b/src/main/java/com/strawberryfarm/fitingle/annotation/Trace.java
@@ -1,0 +1,13 @@
+package com.strawberryfarm.fitingle.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Trace {
+
+}
+

--- a/src/main/java/com/strawberryfarm/fitingle/aop/RetryAspect.java
+++ b/src/main/java/com/strawberryfarm/fitingle/aop/RetryAspect.java
@@ -1,0 +1,30 @@
+package com.strawberryfarm.fitingle.aop;
+
+import com.strawberryfarm.fitingle.annotation.Retry;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+
+@Slf4j
+@Aspect
+public class RetryAspect {
+    @Around("@annotation(retry)")
+    public Object doRetry(ProceedingJoinPoint joinPoint, Retry retry) throws Throwable {
+
+        log.info("[retry] {} retry={}", joinPoint.getSignature(), retry);
+
+        int maxRetry = retry.value();
+        Exception exceptionHolder = null;
+
+        for (int retryCount = 1; retryCount <= maxRetry; retryCount++) {
+            try {
+                log.info("[retry] try count={}/{}", retryCount, maxRetry);
+                return joinPoint.proceed();
+            } catch (Exception e) {
+                exceptionHolder = e;
+            }
+        }
+        throw exceptionHolder;
+    }
+}

--- a/src/main/java/com/strawberryfarm/fitingle/aop/TraceAspect.java
+++ b/src/main/java/com/strawberryfarm/fitingle/aop/TraceAspect.java
@@ -1,0 +1,19 @@
+package com.strawberryfarm.fitingle.aop;
+
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Aspect
+@Component
+public class TraceAspect {
+
+    @Before("@annotation(com.strawberryfarm.fitingle.annotation.Trace)")
+    public void doTrace(JoinPoint joinPoint) {
+        Object[] args = joinPoint.getArgs();
+        log.info("[trace] {} args={}", joinPoint.getSignature(), args);
+    }
+}

--- a/src/main/java/com/strawberryfarm/fitingle/aop/logtrace/LogTrace.java
+++ b/src/main/java/com/strawberryfarm/fitingle/aop/logtrace/LogTrace.java
@@ -1,0 +1,9 @@
+package com.strawberryfarm.fitingle.aop.logtrace;
+
+
+public interface LogTrace {
+
+    TraceStatus begin(String message);
+    void end(TraceStatus status);
+    void exception(TraceStatus status, Exception e);
+}

--- a/src/main/java/com/strawberryfarm/fitingle/aop/logtrace/LogTraceAspect.java
+++ b/src/main/java/com/strawberryfarm/fitingle/aop/logtrace/LogTraceAspect.java
@@ -1,0 +1,36 @@
+package com.strawberryfarm.fitingle.aop.logtrace;
+
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Aspect
+public class LogTraceAspect {
+
+    private final LogTrace logTrace;
+
+    public LogTraceAspect(LogTrace logTrace) {
+        this.logTrace = logTrace;
+    }
+
+    @Around("execution(* com.strawberryfarm.fitingle.domain..*(..))")
+    public Object execute(ProceedingJoinPoint joinPoint) throws Throwable {
+        TraceStatus status = null;
+        try {
+            String message = joinPoint.getSignature().toShortString();
+            status = logTrace.begin(message);
+
+            //로직 호출
+            Object result = joinPoint.proceed();
+
+            logTrace.end(status);
+            return result;
+        } catch (Exception e) {
+            logTrace.exception(status, e);
+            throw e;
+        }
+    }
+}

--- a/src/main/java/com/strawberryfarm/fitingle/aop/logtrace/ThreadLocalLogTrace.java
+++ b/src/main/java/com/strawberryfarm/fitingle/aop/logtrace/ThreadLocalLogTrace.java
@@ -1,0 +1,72 @@
+package com.strawberryfarm.fitingle.aop.logtrace;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class ThreadLocalLogTrace implements LogTrace {
+
+    private static final String START_PREFIX = "-->";
+    private static final String COMPLETE_PREFIX = "<--";
+    private static final String EX_PREFIX = "<X-";
+
+    private ThreadLocal<TraceId> traceIdHolder = new ThreadLocal<>();
+
+    @Override
+    public TraceStatus begin(String message) {
+        syncTraceId();
+        TraceId traceId = traceIdHolder.get();
+        Long startTimeMs = System.currentTimeMillis();
+        log.info("[{}] {}{}", traceId.getId(), addSpace(START_PREFIX, traceId.getLevel()), message);
+
+        return new TraceStatus(traceId, startTimeMs, message);
+    }
+
+    @Override
+    public void end(TraceStatus status) {
+        complete(status, null);
+    }
+
+    @Override
+    public void exception(TraceStatus status, Exception e) {
+        complete(status, e);
+    }
+
+    private void complete(TraceStatus status, Exception e) {
+        Long stopTimeMs = System.currentTimeMillis();
+        long resultTimeMs = stopTimeMs - status.getStartTimeMs();
+        TraceId traceId = status.getTraceId();
+        if (e == null) {
+            log.info("[{}] {}{} time={}ms", traceId.getId(), addSpace(COMPLETE_PREFIX, traceId.getLevel()), status.getMessage(), resultTimeMs);
+        } else {
+            log.info("[{}] {}{} time={}ms ex={}", traceId.getId(), addSpace(EX_PREFIX, traceId.getLevel()), status.getMessage(), resultTimeMs, e.toString());
+        }
+
+        releaseTraceId();
+    }
+
+    private void syncTraceId() {
+        TraceId traceId = traceIdHolder.get();
+        if (traceId == null) {
+            traceIdHolder.set(new TraceId());
+        } else {
+            traceIdHolder.set(traceId.createNextId());
+        }
+    }
+
+    private void releaseTraceId() {
+        TraceId traceId = traceIdHolder.get();
+        if (traceId.isFirstLevel()) {
+            traceIdHolder.remove();//destroy
+        } else {
+            traceIdHolder.set(traceId.createPreviousId());
+        }
+    }
+
+    private static String addSpace(String prefix, int level) {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < level; i++) {
+            sb.append( (i == level - 1) ? "|" + prefix : "|   ");
+        }
+        return sb.toString();
+    }
+}

--- a/src/main/java/com/strawberryfarm/fitingle/aop/logtrace/TraceId.java
+++ b/src/main/java/com/strawberryfarm/fitingle/aop/logtrace/TraceId.java
@@ -1,0 +1,43 @@
+package com.strawberryfarm.fitingle.aop.logtrace;
+
+import java.util.UUID;
+
+public class TraceId {
+
+    private String id;
+    private int level;
+
+    public TraceId() {
+        this.id = createId();
+        this.level = 0;
+    }
+
+    private TraceId(String id, int level) {
+        this.id = id;
+        this.level = level;
+    }
+
+    private String createId() {
+        return UUID.randomUUID().toString().substring(0, 8);
+    }
+
+    public TraceId createNextId() {
+        return new TraceId(id, level + 1);
+    }
+
+    public TraceId createPreviousId() {
+        return new TraceId(id, level - 1);
+    }
+
+    public boolean isFirstLevel() {
+        return level == 0;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public int getLevel() {
+        return level;
+    }
+}

--- a/src/main/java/com/strawberryfarm/fitingle/aop/logtrace/TraceStatus.java
+++ b/src/main/java/com/strawberryfarm/fitingle/aop/logtrace/TraceStatus.java
@@ -1,0 +1,26 @@
+package com.strawberryfarm.fitingle.aop.logtrace;
+
+public class TraceStatus {
+
+    private TraceId traceId;
+    private Long startTimeMs;
+    private String message;
+
+    public TraceStatus(TraceId traceId, Long startTimeMs, String message) {
+        this.traceId = traceId;
+        this.startTimeMs = startTimeMs;
+        this.message = message;
+    }
+
+    public Long getStartTimeMs() {
+        return startTimeMs;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public TraceId getTraceId() {
+        return traceId;
+    }
+}

--- a/src/main/java/com/strawberryfarm/fitingle/config/AopConfig.java
+++ b/src/main/java/com/strawberryfarm/fitingle/config/AopConfig.java
@@ -1,0 +1,21 @@
+package com.strawberryfarm.fitingle.config;
+
+import com.strawberryfarm.fitingle.aop.logtrace.LogTrace;
+import com.strawberryfarm.fitingle.aop.logtrace.LogTraceAspect;
+import com.strawberryfarm.fitingle.aop.logtrace.ThreadLocalLogTrace;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class AopConfig {
+
+    @Bean
+    public LogTraceAspect logTraceAspect(LogTrace logTrace) {
+        return new LogTraceAspect(logTrace);
+    }
+
+    @Bean
+    public LogTrace logTrace() {
+        return new ThreadLocalLogTrace();
+    }
+}

--- a/src/main/java/com/strawberryfarm/fitingle/domain/board/controller/BoardController.java
+++ b/src/main/java/com/strawberryfarm/fitingle/domain/board/controller/BoardController.java
@@ -8,6 +8,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -23,6 +24,7 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
 @RestController
+@Slf4j
 @RequestMapping(value = "/boards", produces = MediaType.APPLICATION_JSON_VALUE)
 @RequiredArgsConstructor
 @Tag(name = "Board", description = "Board API")
@@ -64,5 +66,13 @@ public class BoardController {
         Long userId = Long.parseLong(userDetails.getUsername());
         return ResponseEntity.ok(boardService.boardSearch(userId, keyword, page, size));
     }
-
+    //trace, debug 안보
+    @GetMapping("/test")
+    public void test() {
+        log.trace("TRACE!!");
+        log.debug("DEBUG!!");
+        log.info("INFO!!");
+        log.warn("WARN!!");
+        log.error("ERROR!!");
+    }
 }

--- a/src/main/java/com/strawberryfarm/fitingle/domain/board/service/BoardService.java
+++ b/src/main/java/com/strawberryfarm/fitingle/domain/board/service/BoardService.java
@@ -1,5 +1,6 @@
 package com.strawberryfarm.fitingle.domain.board.service;
 
+import com.strawberryfarm.fitingle.annotation.Trace;
 import com.strawberryfarm.fitingle.domain.ErrorCode;
 import com.strawberryfarm.fitingle.domain.board.dto.BoardDetailResponseDTO;
 import com.strawberryfarm.fitingle.domain.board.dto.BoardRegisterRequestDTO;
@@ -55,6 +56,7 @@ public class BoardService {
 
     //BOARDS 등록
     @Transactional
+    @Trace
     public ResultDto<BoardRegisterResponseDTO> boardRegister(BoardRegisterRequestDTO boardRegisterRequestDTO,
                                                              List<MultipartFile> images,
                                                              Long userId) {

--- a/src/main/java/com/strawberryfarm/fitingle/domain/field/service/FieldService.java
+++ b/src/main/java/com/strawberryfarm/fitingle/domain/field/service/FieldService.java
@@ -1,5 +1,6 @@
 package com.strawberryfarm.fitingle.domain.field.service;
 
+import com.strawberryfarm.fitingle.annotation.Trace;
 import com.strawberryfarm.fitingle.domain.field.dto.FieldsResponseDTO;
 import com.strawberryfarm.fitingle.domain.field.entity.Field;
 import com.strawberryfarm.fitingle.domain.field.repository.FieldRepository;
@@ -35,6 +36,7 @@ public class FieldService {
         return nameMapping.getOrDefault(fieldName, fieldName);
     }
 
+    @Trace
     public void saveFieldsToDatabase() {
         List<S3Object> fieldObjects = s3Manager.listObjectsFromS3("fields/");
         for (S3Object fieldObject : fieldObjects) {
@@ -49,6 +51,7 @@ public class FieldService {
     }
 
 
+    @Trace
     public ResultDto getAllFields() {
         List<Field> fields = fieldRepository.findAll();
         List<FieldsResponseDTO> fieldDtos = new ArrayList<>();

--- a/src/main/java/com/strawberryfarm/fitingle/scheduler/FieldScheduler.java
+++ b/src/main/java/com/strawberryfarm/fitingle/scheduler/FieldScheduler.java
@@ -1,5 +1,6 @@
 package com.strawberryfarm.fitingle.scheduler;
 
+import com.strawberryfarm.fitingle.annotation.Trace;
 import com.strawberryfarm.fitingle.domain.field.service.FieldService;
 import javax.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <!-- 로그 패턴에 색상 적용 %clr(pattern){color} -->
+    <conversionRule conversionWord="clr" converterClass="org.springframework.boot.logging.logback.ColorConverter" />
+
+    <!-- log 기록 절대 위치 설정 -->
+    <property name="LOGS_ABSOLUTE_PATH" value="./logs" />
+
+    <!-- 로그 패턴 변수 설정 -->
+    <property name="CONSOLE_LOG_PATTERN"
+              value="[%d{yyyy-MM-dd HH:mm:ss}:%-3relative]  %clr(%-5level) %clr(${PID:-}){magenta} %clr(---){faint} %clr([%15.15thread]){faint} %clr(%-40.40logger{36}){cyan} %clr(:){faint} %msg%n"/>
+
+    <property name="FILE_LOG_PATTERN"
+              value="[%d{yyyy-MM-dd HH:mm:ss}:%-3relative] %-5level ${PID:-} --- [%15.15thread] %-40.40logger{36} : %msg%n"/>
+
+    <!-- 콘솔(STDOUT) -->
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <layout class="ch.qos.logback.classic.PatternLayout">
+            <Pattern>${CONSOLE_LOG_PATTERN}</Pattern>
+        </layout>
+    </appender>
+
+    <!-- 파일(FILE) -->
+    <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <!--     log 기록할 파일 위치 설정 -->
+        <file>${LOGS_ABSOLUTE_PATH}/logback.log</file>
+        <!--     log 기록 타입 인코딩 -->
+        <encoder>
+            <pattern>${FILE_LOG_PATTERN}</pattern>
+        </encoder>
+
+        <!-- 로그파일을 교체하는 정책 TimeBasedRollingPolicy: 시간 단위 -->
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <!-- 파일 이름 -->
+            <fileNamePattern>${LOGS_ABSOLUTE_PATH}/logFile.%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+            <!-- 파일의 최대 저장 기한 -->
+            <maxHistory>10</maxHistory>
+            <!-- 개별 로그 파일의 사이즈 제한, 도달하면 새 파일로 롤링-->
+            <maxFileSize>10KB</maxFileSize>
+            <!-- 전체 로그 파일 크기를 제어하며, 용량을 초과하면 가장 오래된 파일 삭제 -->
+            <totalSizeCap>3GB</totalSizeCap>
+        </rollingPolicy>
+    </appender>
+
+    <!-- root 로거 설정 -->
+    <root level="INFO">
+        <appender-ref ref="STDOUT" />
+    </root>
+
+    <!-- log 레벨 설정 (org.springframework.web=debug)-->
+    <logger name="com.strawberryfarm.fitingle" level="DEBUG">
+        <appender-ref ref="FILE" />
+    </logger>
+
+
+</configuration>


### PR DESCRIPTION

> 사용자 커스텀 어노테이션

Retry, trace : 어노테이션 설정

RetryAspect : @Retry 어노테이션이 붙은 메소드에 대해 지정된 횟수만큼 재시도(retry) 로직을 적용하는 Aspect
TraceAspect : @Trace 어노테이션이 붙은 메소드가 호출되기 전에 메소드 이름과 인자들을 로깅하는 Aspect

------------------------------------
> 전역 AOP 설정

LogTrace : 로깅을 위한 인터페이스 LogTrace를 정의.

LogTraceAspect : @Around 어노테이션을 사용하여  패키지 내의 모든 메소드 호출에 이 로깅 로직을 적용.

ThreadLocalLogTrace : 로그 추적의 시작부터 종료까지의 전 과정을 담당, 특히 멀티 스레드 환경에서 각 스레드의 로그를 구분하여 추적.

TraceId : TraceId 클래스는 로깅을 위한 추적 ID를 관리하는 클래스. 이 클래스의 인스턴스는 각 로그가 수행되는 작업의 고유 식별자(id)와 해당 작업의 깊이 또는 레벨(level)을 가지고 있음.

TraceStatus : TraceStatus 클래스는 로그 추적의 상태를 나타내는 클래스.

AopConfig :  AOP 관련 빈 설정을 담당하는 Java 설정 클래스.

------------------------------------------

> Logback 구성 파일( SLFj4 구현체로 로깅 동작 정의 및 설정)

logback-spring.xml : 

1.  색상 적용을 위한 변환 규칙: 로그 패턴에 색상을 적용하기 위해 ColorConverter 클래스를 사용하는 변환 규칙을 정의.

2. 로그 파일 위치 설정: 로그 파일의 절대 경로를 ./logs로 설정.
 
3. 로그 패턴 설정: 콘솔 출력(CONSOLE_LOG_PATTERN)과 파일 출력(FILE_LOG_PATTERN)에 사용될 로그 패턴을 정의. 이 패턴은 로그 메시지의 형식을 결정.
 
4. 콘솔 로거(STDOUT) 설정: 표준 출력(콘솔)으로 로그를 출력하기 위한 ConsoleAppender를 설정.
 
5. 파일 로거(FILE) 설정: 로그 메시지를 파일로 기록하기 위한 RollingFileAppender를 설정.
 이 설정에는 파일의 위치, 인코딩, 롤링 정책이 포함된다. SizeAndTimeBasedRollingPolicy를 사용하여 로그 파일의 크기와 보관 기간을 제한.
(롤링 : 일정 기준(예: 파일 크기, 시간 등)에 도달했을 때 기존 로그 파일을 새로운 파일로 교체하는 과정) 

6. 루트 로거 설정: 애플리케이션 전반에 걸쳐 사용할 기본 로그 레벨을 INFO로 설정하고, 콘솔 애펜더를 참조.
 
7. 특정 패키지 로거 설정: com.strawberryfarm.fitingle 패키지의 로그 레벨을 DEBUG로 설정하고, 이 로그 메시지를 파일 애펜더로 출력한다.